### PR TITLE
Update NetworkInfo host and improve connectivity check

### DIFF
--- a/lib/core/network/network_info.dart
+++ b/lib/core/network/network_info.dart
@@ -5,19 +5,18 @@ abstract class NetworkInfo {
 }
 
 class NetworkInfoImpl implements NetworkInfo {
-  const NetworkInfoImpl({this.host = 'example.com'});
+  const NetworkInfoImpl({this.host = 'google.com'});
 
   final String host;
 
   @override
   Future<bool> get isConnected async {
     try {
-      final List<InternetAddress> result = await InternetAddress.lookup(host);
-      if (result.isNotEmpty && result.first.rawAddress.isNotEmpty) {
-        return true;
-      }
-      return false;
-    } on SocketException {
+      final result = await InternetAddress.lookup(host)
+          .timeout(const Duration(seconds: 3));
+      return result.isNotEmpty && result.first.rawAddress.isNotEmpty;
+    } catch (e) {
+      print('Network check failed: $e'); // works in release mode too
       return false;
     }
   }

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -22,7 +22,7 @@ final GetIt serviceLocator = GetIt.instance;
 Future<void> setupDependencyInjection() async {
   // Core
   serviceLocator.registerLazySingleton<Dio>(() => createDioClient());
-  serviceLocator.registerLazySingleton<NetworkInfo>(() => const NetworkInfoImpl(host: 'dummyjson.com'));
+  serviceLocator.registerLazySingleton<NetworkInfo>(() => const NetworkInfoImpl());
   serviceLocator.registerLazySingleton<LocalNotificationsService>(
     () => LocalNotificationsService(),
   );


### PR DESCRIPTION
Changed default host in NetworkInfoImpl from 'example.com' to 'google.com' and improved error handling in the connectivity check with a timeout and logging. Updated dependency injection to use the default host.